### PR TITLE
Added sanity check to number of threads

### DIFF
--- a/structure_threader.py
+++ b/structure_threader.py
@@ -143,12 +143,20 @@ if __name__ == "__main__":
     infile = arg.infile
     outpath = arg.outpath
 
+    # Make cpu usage check to prevent excessive usage of threads
+    try:
+        if int(arg.threads) > os.cpu_count():
+            print("WARNING: Number of specified threads is higher than the"
+                  " available ones. Adjusting number of threads to %s" %
+                  os.cpu_count())
+            threads = os.cpu_count()
+        else:
+            threads = arg.threads
+    except:
+        threads = arg.threads
+
     # Check for output directory, create if it doesn't exist
-    if not os.path.exists(outpath) or not os.path.isdir(outpath):
-        try:
-            os.makedirs(outpath)
-        except FileExistsError:
-            print("ERROR: Output directory already exists.")
-            raise SystemExit
+    if not os.path.exists(outpath):
+        os.makedirs(outpath)
 
     structure_threader(Ks, replicates, arg.threads)

--- a/structure_threader.py
+++ b/structure_threader.py
@@ -156,7 +156,11 @@ if __name__ == "__main__":
         threads = arg.threads
 
     # Check for output directory, create if it doesn't exist
-    if not os.path.exists(outpath):
-        os.makedirs(outpath)
+    if not os.path.exists(outpath) or not os.path.isdir(outpath):
+        try:
+            os.makedirs(outpath)
+        except FileExistsError:
+            print("ERROR: Output directory already exists.")
+            raise SystemExit
 
     structure_threader(Ks, replicates, arg.threads)


### PR DESCRIPTION
Just added a sanity check for the number of threads being used. In case a user selects a number of threads higher than the ones available on the system, the program would run much slower. This new code will compare the specified threads to the available ones on the system and, if necessary, will reduce the number of threads to avoid thread competition.

This should be compatible across platforms, but it handles any exceptions nonetheless. Should anything go south, it will just use the number of threads specified by the user. 
